### PR TITLE
Reject password inputs looking like raw bcrypt

### DIFF
--- a/nodes/http-auth.js
+++ b/nodes/http-auth.js
@@ -13,21 +13,32 @@ try {
  */
 const bcryptCache = {};
 
+/**
+ * Is the password matching the Modular Crypt Format of bcrypt
+ */
+function isBcryptMcf(hash) {
+	return (typeof hash === 'string') && hash.match(/^\$2[abxy]?\$/);
+}
+
 function passwordCompare(plain, hash) {
 	if (plain == '' || hash == '') {
 		return false;
 	}
-	if (plain === hash) {
+
+	// Test for plain-text passwords, excluding what looks like a bcrypt password (MCF)
+	if (plain === hash && !isBcryptMcf(plain)) {
 		return true;
 	}
 
 	// Compatibility work-around for 'bcrypt' library
 	hash = hash.replace(/^\$2[x|y]\$/, '$2b$');
 
+	// Do we already have a cache of the password check
 	if (plain === bcryptCache[hash]) {
 		return true;
 	}
 
+	// Test for bcrypt
 	const success = bcrypt.compareSync(plain, hash);
 
 	if (success) {

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-# Accept bcrypt password, also a second attempt (cached)
+# Accept password saved as bcrypt, also a second attempt (cached)
 
 test=$(
-	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
-{"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
-{"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
+	cat <<EOF | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
+{"req":{"headers":{"authorization":"Basic $(printf 'test:test' | base64 -w 0)"}}}
+{"req":{"headers":{"authorization":"Basic $(printf 'test:test' | base64 -w 0)"}}}
 EOF
 )
 
@@ -14,11 +14,11 @@ if [ "$test" = "" ]; then
 	exit 1
 fi
 
-# Accept plain-text password
+# Accept password saved as plain-text
 
 test=$(
-	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"test"'
-{"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
+	cat <<EOF | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"test"'
+{"req":{"headers":{"authorization":"Basic $(printf 'test:test' | base64 -w 0)"}}}
 EOF
 )
 
@@ -30,8 +30,8 @@ fi
 # Reject wrong user
 
 test=$(
-	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"wrong"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
-{"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
+	cat <<EOF | node ./index.js http-basic-auth --realm='"node-red"' --username='"wrong"' --password='"test"'
+{"req":{"headers":{"authorization":"Basic $(printf 'test:test' | base64 -w 0)"}}}
 EOF
 )
 
@@ -43,8 +43,8 @@ fi
 # Reject wrong password
 
 test=$(
-	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"wrong"'
-{"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
+	cat <<EOF | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"wrong"'
+{"req":{"headers":{"authorization":"Basic $(printf 'test:test' | base64 -w 0)"}}}
 EOF
 )
 
@@ -56,8 +56,8 @@ fi
 # Do not accept bcrypt passwords as input (only plain-text passwords)
 
 test=$(
-	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
-{"req":{"headers":{"authorization":"Basic dGVzdDokMnkkMTAkNVRTWkRsZG9KN014RFpkdEsvU0cyTzNjd09ScUxEaEhhYllsS1g5T3NNLlcvWi9vTHdLVzY="}}}
+	cat <<EOF | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
+{"req":{"headers":{"authorization":"Basic $(printf 'test:$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6' | base64 -w 0)"}}}
 EOF
 )
 

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# Accept bcrypt password, also a second attempt (cached)
+
 test=$(
 	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
 {"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
@@ -12,6 +14,8 @@ if [ "$test" = "" ]; then
 	exit 1
 fi
 
+# Accept plain-text password
+
 test=$(
 	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"test"'
 {"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
@@ -22,6 +26,8 @@ if [ "$test" = "" ]; then
 	echo 'ERROR 2'
 	exit 1
 fi
+
+# Reject wrong user
 
 test=$(
 	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"wrong"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
@@ -34,6 +40,8 @@ if [ "$test" != "" ]; then
 	exit 1
 fi
 
+# Reject wrong password
+
 test=$(
 	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"wrong"'
 {"req":{"headers":{"authorization":"Basic dGVzdDp0ZXN0"}}}
@@ -42,5 +50,18 @@ EOF
 
 if [ "$test" != "" ]; then
 	echo 'ERROR 4'
+	exit 1
+fi
+
+# Do not accept bcrypt passwords as input (only plain-text passwords)
+
+test=$(
+	cat <<'EOF' | node ./index.js http-basic-auth --realm='"node-red"' --username='"test"' --password='"$2y$10$5TSZDldoJ7MxDZdtK/SG2O3cwORqLDhHabYlKX9OsM.W/Z/oLwKW6"'
+{"req":{"headers":{"authorization":"Basic dGVzdDokMnkkMTAkNVRTWkRsZG9KN014RFpkdEsvU0cyTzNjd09ScUxEaEhhYllsS1g5T3NNLlcvWi9vTHdLVzY="}}}
+EOF
+)
+
+if [ "$test" != "" ]; then
+	echo 'ERROR 5'
 	exit 1
 fi


### PR DESCRIPTION
If a password arrives in the authorization header as a string looking like bcrypt (according to standard Modular Crypt Format) instead of normal-looking plain-text, then reject the authentication.
This is to avoid being able to pass the crypted version of the password, in case it was leaked.